### PR TITLE
prevent z-index value from modifying when running yarn prod

### DIFF
--- a/assets/webpack/plugins.js
+++ b/assets/webpack/plugins.js
@@ -130,7 +130,8 @@ const productionPLugins = [
     cssProcessorOptions: {
       discardComments: {
         removeAll: true
-      }
+      },
+      safe: true,
     }
   }),
   new FaviconsWebpackPlugin({


### PR DESCRIPTION
Was wondering that z-index value was different comparing yarn start / yarn prod.

Checkout:
https://github.com/vuejs-templates/webpack/issues/614
https://github.com/roots/sage/commit/00e7150a96a9129e93caae3fa374d40e7f276fe4

Found out that when adding safe: true into cssProcessorOptions ==> z-index value was not modified anymore.